### PR TITLE
Added base url feature + Trailing slash bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,13 @@ node_modules/
 worker/
 .cargo-ok
 package-lock.json
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function handler(request) {
 }
 
 async function handleRequest(request) {
-    const r = new Router()
+    const r = new Router("/api/v1") // The base path is passed as parameter
     // Replace with the approriate paths and handlers
     r.get('.*/bar', () => new Response('responding for /bar'))
     r.get('.*/foo', req => handler(req))

--- a/router.js
+++ b/router.js
@@ -18,10 +18,11 @@ const Trace = Method('trace')
 const Header = (header, val) => req => req.headers.get(header) === val
 const Host = host => Header('host', host.toLowerCase())
 const Referrer = host => Header('referrer', host.toLowerCase())
+const AddSlash = s => s.replace(/\/$/,"")+"/"
 
 const Path = regExp => req => {
     const url = new URL(req.url)
-    const path = url.pathname
+    const path = AddSlash(url.pathname)
     const match = path.match(regExp) || []
     return match[0] === path
 }
@@ -31,7 +32,8 @@ const Path = regExp => req => {
  * conditions present for each request.
  */
 class Router {
-    constructor() {
+    constructor(base) {
+        this.base = base?base.replace(/\/$/,""):""
         this.routes = []
     }
 
@@ -44,39 +46,39 @@ class Router {
     }
 
     connect(url, handler) {
-        return this.handle([Connect, Path(url)], handler)
+        return this.handle([Connect, Path(this.base+AddSlash(url))], handler)
     }
 
     delete(url, handler) {
-        return this.handle([Delete, Path(url)], handler)
+        return this.handle([Delete, Path(this.base+AddSlash(url))], handler)
     }
 
     get(url, handler) {
-        return this.handle([Get, Path(url)], handler)
+        return this.handle([Get, Path(this.base+AddSlash(url))], handler)
     }
 
     head(url, handler) {
-        return this.handle([Head, Path(url)], handler)
+        return this.handle([Head, Path(this.base+AddSlash(url))], handler)
     }
 
     options(url, handler) {
-        return this.handle([Options, Path(url)], handler)
+        return this.handle([Options, Path(this.base+AddSlash(url))], handler)
     }
 
     patch(url, handler) {
-        return this.handle([Patch, Path(url)], handler)
+        return this.handle([Patch, Path(this.base+AddSlash(url))], handler)
     }
 
     post(url, handler) {
-        return this.handle([Post, Path(url)], handler)
+        return this.handle([Post, Path(this.base+AddSlash(url))], handler)
     }
 
     put(url, handler) {
-        return this.handle([Put, Path(url)], handler)
+        return this.handle([Put, Path(this.base+AddSlash(url))], handler)
     }
 
     trace(url, handler) {
-        return this.handle([Trace, Path(url)], handler)
+        return this.handle([Trace, Path(this.base+AddSlash(url))], handler)
     }
 
     all(handler) {


### PR DESCRIPTION
This was developed as a result of a bug found related to trailing "/" in the url. This will fix the bug and ignore the case in which use forget to add "/" in the end of url. It also enable the root of api not just to be "/", but anything that is passed along `new Router(base_url)` parameter.

As per the updated index.js,
`const r = new Router("/api/v1")`
www.example.com/api/v1 => Hello worker
www.example.com/api/v1/ => Hello worker
www.example.com/api/v1/find/bar => responding for /bar
www.example.com/api/v1/find/bar/ => responding for /bar
www.example.com => resource not found
www.example.com/ => resource not found

TODO: Update README & DEMO with `/api/v1` url extension.