### PR TITLE
Update README.md to use lowercase name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Live Demos are hosted on `workers-tooling.cf/demos/router`:
 You can use [wrangler](https://github.com/cloudflare/wrangler) to generate a new Cloudflare Workers project based on this template by running the following command from your terminal:
 
 ```
-wrangler generate myApp https://github.com/cloudflare/worker-template-router
+wrangler generate myapp https://github.com/cloudflare/worker-template-router
 ```
 
 Before publishing your code you need to edit `wrangler.toml` file and add your Cloudflare `account_id` - more information about publishing your code can be found [in the documentation](https://workers.cloudflare.com/docs/quickstart/configuring-and-publishing/).


### PR DESCRIPTION
This (awesome!) template needs a new default app name to make it Wrangler-happy:
```
Error: Worker name "myApp" invalid. Ensure that you only use lowercase letters, dashes, underscores, and numbers.
```